### PR TITLE
fix: release workflow

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */


### PR DESCRIPTION
What happened:
- Deleting the TestRunners target in Xcode 16.4 upgraded the project format to version 70 (#130)
- CocoaPods 1.16.2 (with xcodeproj 1.27.0) doesn't support version 70
- Version 60 is compatible with the current CocoaPods setup and works with Xcode 16.4

- [x] Changelog updated (if applicable)
